### PR TITLE
feat: RAID creation: Automatically find and create next RAID device

### DIFF
--- a/applications/luci-app-diskman/luasrc/model/cbi/diskman/disks.lua
+++ b/applications/luci-app-diskman/luasrc/model/cbi/diskman/disks.lua
@@ -217,7 +217,7 @@ if dm.command.mdadm then
 
   local rname, rmembers, rlevel
   local r_name = creation_section:taboption("raid", Value, "_rname", translate("Raid Name"))
-  r_name.placeholder = "/dev/md0"
+  r_name.placeholder = dm.find_free_md_device()
   r_name.write = function(self, section, value)
     rname = value
   end

--- a/applications/luci-app-diskman/luasrc/model/diskman.lua
+++ b/applications/luci-app-diskman/luasrc/model/diskman.lua
@@ -474,6 +474,18 @@ d.get_format_cmd = function()
   return result
 end
 
+d.find_free_md_device = function()
+  for num=0,127 do
+    local md = io.open("/dev/md"..tostring(num), "r")
+    if md == nil then
+      return "/dev/md"..tostring(num)
+    else
+      io.close(md)
+    end
+  end
+  return nil
+end
+
 d.create_raid = function(rname, rlevel, rmembers)
   local mb = {}
   for _, v in ipairs(rmembers) do
@@ -494,18 +506,8 @@ d.create_raid = function(rname, rlevel, rmembers)
       return "ERR: Invalid raid name"
     end
   else
-    local mdnum = 0
-    for num=1,127 do
-      local md = io.open("/dev/md"..tostring(num), "r")
-      if md == nil then
-        mdnum = num
-        break
-      else
-        io.close(md)
-      end
-    end
-    if mdnum == 0 then return "ERR: Cannot find proper md number" end
-    rname = "/dev/md"..mdnum
+    rname = d.find_free_md_device()
+    if rname == nil then return "ERR: Cannot find free md device" end
   end
 
   if rlevel == "5" or rlevel == "6" then


### PR DESCRIPTION
Note that the current default actually has a bug where, despite the
placeholder saying '/dev/md0', the actual path created by default is
/dev/md1.

This change moves to match the user's expectations by actually using
the placeholder that they see.