### PR TITLE
fix extended partition detection

### DIFF
--- a/applications/luci-app-diskman/luasrc/model/diskman.lua
+++ b/applications/luci-app-diskman/luasrc/model/diskman.lua
@@ -225,10 +225,10 @@ local get_parted_info = function(device)
           p["type"] = "logical"
           table.insert(partitions_temp[disk_temp["extended_partition_index"]]["logicals"], i)
         end
-      elseif (p["number"] < 4) and (p["number"] > 0) then
+      elseif (p["number"] <= 4) and (p["number"] > 0) then
         local s = nixio.fs.readfile("/sys/block/"..device.."/"..p["name"].."/size")
         if s then
-          local real_size_sec = tonumber(s) * tonumber(disk_temp.phy_sec)
+          local real_size_sec = tonumber(s) * tonumber(disk_temp.logic_sec)
           -- if size not equal, it's an extended
           if real_size_sec ~= p["size"] then
             disk_temp["extended_partition_index"] = i


### PR DESCRIPTION
原有的扩展分区识别有bug：
1. 对于物理扇区大小非512的硬盘，会将所有分区都认为是扩展分区，并且`size`也是错的
2. 对于第4分区是扩展分区的情况，代码会跳过，导致没识别到扩展分区