### PR TITLE
fix crash get_smart_info on nvme on virtualbox

### DIFF
--- a/applications/luci-app-diskman/luasrc/model/diskman.lua
+++ b/applications/luci-app-diskman/luasrc/model/diskman.lua
@@ -74,7 +74,9 @@ local get_smart_info = function(device)
     elseif attrib == "Serial Number" then
       smart_info.sn = val
     elseif attrib == "194" or attrib == "Temperature" then
-      smart_info.temp = val:match("(%d+)") .. "°C"
+      if val ~= "-" then
+        smart_info.temp = (val:match("(%d+)") or "?") .. "°C"
+      end
     elseif attrib == "Rotation Rate" then
       smart_info.rota_rate = val
     elseif attrib == "SATA Version is" then


### PR DESCRIPTION
在virtualbox下测试

配置一个nvme硬盘

开机以后打开页面 **/cgi-bin/luci/admin/system/diskman/partition/nvme0n1** ，产生错误：
```
/usr/lib/lua/luci/model/diskman.lua:77: attempt to concatenate a nil value
stack traceback:
	/usr/lib/lua/luci/model/diskman.lua:77: in function 'get_smart_info'
	/usr/lib/lua/luci/model/diskman.lua:306: in function 'get_disk_info'
	/usr/lib/lua/luci/controller/diskman.lua:68: in function </usr/lib/lua/luci/controller/diskman.lua:57>
```
https://github.com/lisaac/luci-app-diskman/blob/4e118b6f8c30be5341975eb3caa630fd1ee6fbd2/applications/luci-app-diskman/luasrc/model/diskman.lua#L77

原因是smartctl从virtualbox的虚拟nvme读取出来的温度值是“-”，执行上述代码会产生 nil 错误。尚不知道是否影响物理机。

附smartctl的输出 （`smartctl  -H -A -i -n standby -f brief /dev/nvme0n1`）：
```plain
smartctl 7.2 2020-12-30 r5155 [x86_64-linux-5.4.188] (localbuild)
Copyright (C) 2002-20, Bruce Allen, Christian Franke, www.smartmontools.org

=== START OF INFORMATION SECTION ===
Model Number:                       ORCL-VBOX-NVME-VER12
Serial Number:                      VB1234-56789
Firmware Version:                   1.0
PCI Vendor/Subsystem ID:            0x80ee
IEEE OUI Identifier:                0x000000
Controller ID:                      0
NVMe Version:                       1.2
Number of Namespaces:               18
Namespace 1 Size/Capacity:          4,294,967,296 [4.29 GB]
Namespace 1 Formatted LBA Size:     512
Local Time is:                      Sat Feb  4 10:50:04 2023 CST

=== START OF SMART DATA SECTION ===
SMART overall-health self-assessment test result: PASSED

SMART/Health Information (NVMe Log 0x02)
Critical Warning:                   0x00
Temperature:                        -
Available Spare:                    0%
Available Spare Threshold:          0%
Percentage Used:                    0%
Data Units Read:                    0
Data Units Written:                 0
Host Read Commands:                 0
Host Write Commands:                0
Controller Busy Time:               0
Power Cycles:                       0
Power On Hours:                     0
Unsafe Shutdowns:                   0
Media and Data Integrity Errors:    0
Error Information Log Entries:      0
Warning  Comp. Temperature Time:    0
Critical Comp. Temperature Time:    0

```