### PR TITLE
Enforce new version format

### DIFF
--- a/applications/luci-app-diskman/Makefile
+++ b/applications/luci-app-diskman/Makefile
@@ -2,8 +2,8 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=luci-app-diskman
 LUCI_NAME:=luci-app-diskman
-PKG_VERSION:=v0.2.13
-PKG_RELEASE:=beta
+PKG_VERSION:=0.2.13
+PKG_RELEASE:=1
 PKG_MAINTAINER:=lisaac <https://github.com/lisaac/luci-app-diskman>
 PKG_LICENSE:=AGPL-3.0
 


### PR DESCRIPTION
Version formats that do not conform to the standard will fail to build in the new version of OpenWRT.