### PR TITLE
update to kmod-fs-ntfs3

### DIFF
--- a/applications/luci-app-diskman/Makefile
+++ b/applications/luci-app-diskman/Makefile
@@ -12,7 +12,7 @@ LUCI_TITLE:=Disk Manager interface for LuCI
 LUCI_DEPENDS:=+luci-compat +luci-lib-ipkg +e2fsprogs +parted +smartmontools +blkid \
 	+kmod-fs-vfat +dosfstools +kmod-fs-msdos +kmod-nls-base +kmod-nls-utf8 +kmod-nls-cp932 +kmod-nls-cp936 +kmod-nls-cp950 \
 	+kmod-fs-exfat +exfat-mkfs +exfat-fsck \
-	+kmod-fs-ntfs \
+	+kmod-fs-ntfs3 \
 	+kmod-fs-btrfs \
 	+PACKAGE_$(PKG_NAME)_INCLUDE_ntfs_3g_utils:ntfs-3g-utils \
 	+PACKAGE_$(PKG_NAME)_INCLUDE_btrfs_progs:btrfs-progs \


### PR DESCRIPTION
```kmod-fs-ntfs``` is no longer supported on linux 6.12, switch to ```kmod-fs-ntfs3``` instead.