### PR TITLE
Remove luci-lib-ipkg and add support for some USB Disk enclosure

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@
 
 ## Depends / 依赖
 - luci-compat
-- luci-lib-ipkg
 - [parted](https://github.com/lisaac/luci-app-diskman/blob/master/Parted.Makefile)
 - blkid
 - smartmontools

--- a/applications/luci-app-diskman/Makefile
+++ b/applications/luci-app-diskman/Makefile
@@ -9,7 +9,7 @@ PKG_LICENSE:=AGPL-3.0
 
 LUCI_TITLE:=Disk Manager interface for LuCI
 
-LUCI_DEPENDS:=+luci-compat +luci-lib-ipkg +e2fsprogs +parted +smartmontools +blkid \
+LUCI_DEPENDS:=+luci-compat +e2fsprogs +parted +smartmontools +blkid \
 	+kmod-fs-vfat +dosfstools +kmod-fs-msdos +kmod-nls-base +kmod-nls-utf8 +kmod-nls-cp932 +kmod-nls-cp936 +kmod-nls-cp950 \
 	+kmod-fs-exfat +exfat-mkfs +exfat-fsck \
 	+kmod-fs-ntfs3 \

--- a/applications/luci-app-diskman/luasrc/controller/diskman.lua
+++ b/applications/luci-app-diskman/luasrc/controller/diskman.lua
@@ -108,11 +108,9 @@ end
 function smart_attr(dev)
   local attr = { }
   local dm = require "luci.model.diskman"
-  local cmd = io.popen(dm.command.smartctl ..  " -H -A -i /dev/%s" % dev)
-  if cmd then
-    local content = cmd:read("*all")
+  local content = dm.smartctl_output(dev, "-H -A -i")
+  if content and content ~= "" then
     local ln
-    cmd:close()
     if content:match("NVMe Version:")then
       for ln in string.gmatch(content,'[^\r\n]+') do
         if ln:match("^(.-):%s+(.+)") then

--- a/applications/luci-app-diskman/luasrc/model/diskman.lua
+++ b/applications/luci-app-diskman/luasrc/model/diskman.lua
@@ -14,6 +14,139 @@ for _, cmd in ipairs(CMD) do
     d.command[cmd] = command:match("^.+"..cmd) or nil
 end
 
+local function sysfs_transport(device)
+  local path = (luci.util.exec("readlink -f /sys/class/block/" .. device .. "/device 2>/dev/null") or ""):match("%S+")
+  if not path then
+    return nil
+  end
+
+  local seen = {}
+  local parent = path
+  while parent and parent ~= "/" do
+    local subsystem = (luci.util.exec("readlink -f " .. parent .. "/subsystem 2>/dev/null") or ""):match("([^/]+)$")
+    if subsystem then
+      seen[subsystem] = true
+    end
+    parent = parent:match("^(.*)/[^/]+$")
+  end
+
+  if seen.usb then
+    return "usb"
+  elseif seen.nvme then
+    return "nvme"
+  elseif seen.ata then
+    return "ata"
+  elseif seen.scsi then
+    return "scsi"
+  end
+
+  return nil
+end
+
+local function udevadm_transport(device)
+  if luci.sys.exec("which udevadm") == "" then
+    return nil
+  end
+
+  local cmd = io.popen("udevadm info --query=property --name=/dev/" .. device .. " 2>/dev/null")
+  if not cmd then
+    return nil
+  end
+
+  local transport
+  for line in cmd:lines() do
+    local key, value = line:match("^(%S+)=(.*)$")
+    if key == "ID_BUS" and value and value ~= "" then
+      transport = value
+      break
+    end
+  end
+  cmd:close()
+
+  return transport
+end
+
+local function lsblk_transport(device)
+  if not d.command.lsblk then
+    return nil
+  end
+
+  local transport = (luci.util.exec(d.command.lsblk .. " -dn -o TRAN /dev/" .. device .. " 2>/dev/null") or ""):match("(%S+)")
+  if transport and transport ~= "-" then
+    return transport
+  end
+
+  return nil
+end
+
+local function device_transport(device)
+  return lsblk_transport(device) or udevadm_transport(device) or sysfs_transport(device)
+end
+
+local function smartctl_candidates(device)
+  local transport = device_transport(device)
+  if device:match("^nvme%d+n%d+") or device:match("^nvme%d+$") or transport == "nvme" then
+    return { "nvme", "" }
+  end
+  if transport == "usb" then
+    return { "sat", "scsi", "" }
+  end
+
+  return { "", "sat", "scsi" }
+end
+
+local function run_smartctl(device, devtype, options)
+  if not d.command.smartctl then
+    return ""
+  end
+
+  local cmd = d.command.smartctl
+  if devtype and devtype ~= "" then
+    cmd = cmd .. " -d " .. devtype
+  end
+  if options and options ~= "" then
+    cmd = cmd .. " " .. options
+  end
+  cmd = cmd .. " /dev/" .. device .. " 2>&1"
+
+  local pipe = io.popen(cmd)
+  if not pipe then
+    return ""
+  end
+
+  local output = pipe:read("*all") or ""
+  pipe:close()
+  return output
+end
+
+local function smartctl_success(output)
+  return output:match("START OF INFORMATION SECTION")
+    or output:match("START OF SMART DATA SECTION")
+    or output:match("NVMe Version:")
+    or output:match("Serial Number:")
+    or output:match("SMART Health Status:")
+    or output:match("Device is in [A-Z]+ mode")
+end
+
+local function smartctl_output(device, options)
+  options = options or ""
+  local fallback
+
+  for _, devtype in ipairs(smartctl_candidates(device)) do
+    local output = run_smartctl(device, devtype, options)
+    if output ~= "" then
+      fallback = fallback or output
+      if smartctl_success(output) then
+        return output
+      end
+    end
+  end
+
+  return fallback or ""
+end
+
+d.smartctl_output = smartctl_output
+
 d.command.mount = nixio.fs.access("/usr/bin/mount") and "/usr/bin/mount" or "/bin/mount"
 d.command.umount = nixio.fs.access("/usr/bin/umount") and "/usr/bin/umount" or "/bin/umount"
 
@@ -36,7 +169,7 @@ end
 local get_smart_info = function(device)
   local section
   local smart_info = {}
-  for _, line in ipairs(luci.util.execl(d.command.smartctl .. " -H -A -i -n standby -f brief /dev/" .. device)) do
+  for line in (d.smartctl_output(device, "-H -A -i -n standby -f brief") or ""):gmatch("[^\r\n]+") do
     local attrib, val
     if section == 1 then
         attrib, val = line:match "^(.-):%s+(.+)"


### PR DESCRIPTION
1. Remove ```luci-lib-ipkg``` dependency as it is unused and irrelevant to the APK package manager.
2. Check device type using ```lsblk``` ```udevadm``` ```rootfs``` in sequence, so we can use the proper -d flag to display correct smartctl information for USB disk enclosures, NVMe, and SCSI devices.